### PR TITLE
AArch64: Use better block copy8

### DIFF
--- a/lib/common/zstd_internal.h
+++ b/lib/common/zstd_internal.h
@@ -168,7 +168,7 @@ static UNUSED_ATTR const U32 OF_defaultNormLog = OF_DEFAULTNORMLOG;
 *  Shared functions to include for inlining
 *********************************************/
 static void ZSTD_copy8(void* dst, const void* src) {
-#if defined(ZSTD_ARCH_ARM_NEON)
+#if defined(ZSTD_ARCH_ARM_NEON) && !defined(__aarch64__)
     vst1_u8((uint8_t*)dst, vld1_u8((const uint8_t*)src));
 #else
     ZSTD_memcpy(dst, src, 8);


### PR DESCRIPTION
The vector copy is only necessary for 16-byte blocks on AArch64.

Decompression uplifts on a Neoverse V2 system, using Zstd-1.5.8 compiled with "-O3 -march=armv8.2-a+sve2":

```
                 Clang-19  Clang-20    GCC-14    GCC-15
 1#silesia.tar:   +0.316%   +0.244%   +0.045%   +0.088%
 2#silesia.tar:   +0.663%   +0.277%   +0.013%   +0.089%
 3#silesia.tar:   +0.784%   +0.340%   +0.027%   -0.042%
 4#silesia.tar:   +0.830%   +0.310%   -0.069%   -0.179%
 5#silesia.tar:   +0.932%   +0.240%   +0.146%   +0.042%
 6#silesia.tar:   +0.908%   +0.341%   +0.065%   +0.008%
 7#silesia.tar:   +0.825%   +0.304%   +0.077%   -0.165%
 ```